### PR TITLE
fix debian control build issue

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,8 +1,6 @@
 Source: com.github.aleksandar-stefanovic.urmsimulator
 Section: x11
-Priority: extra
 Maintainer: Aleksandar Stefanović <theonewithideas@gmail.com>
-
 Build-Depends: cmake (>= 2.8),
                cmake-elementary,
                libgtk-3-dev,
@@ -11,7 +9,9 @@ Build-Depends: cmake (>= 2.8),
                libgtksourceview-3.0-dev (>= 3.10),
                valac-0.26 | valac (>= 0.26)
 Standards-Version: 3.9.3
+
 Package: com.github.aleksandar-stefanovic.urmsimulator
 Architecture: any
+Priority: extra
 Depends: ${misc:Depends}, ${shlibs:Depends}
 Description: A simple URM Simulator.


### PR DESCRIPTION
The debian control file is a pain to work with. This should fix your builds though.

On a side note, you might want to try running houston in travis to catch build errors before the release process: https://github.com/elementary/houston/wiki/Continuous-Integration